### PR TITLE
Absolute imports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 version: 2
 
 jobs:
-  build:
+  lint:
     working_directory: ~/constable
     docker:
       - image: circleci/node:10
@@ -17,18 +17,29 @@ jobs:
         name: Linting
         command: |
           npm run lint
+  build:
+    working_directory: ~/constable
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/constable
       - run:
           name: Authenticate with registry
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/constable/.npmrc
       - run:
           name: Publish package
-          command: npm publish --access public  
+          command: npm publish --access public
 
 workflows:
   version: 2
-  build-publish:
+  main:
     jobs:
+      - lint
       - build:
+          requires:
+            - lint
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,11 @@ jobs:
       - attach_workspace:
           at: ~/constable
       - run:
-        name: Linting
-        command: |
-          npm run lint
+          name: Install dependencies
+          command: npm run install
+      - run:
+          name: Linting
+          command: npm run lint
   build:
     working_directory: ~/constable
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,6 @@ jobs:
       - image: circleci/node:10
     steps:
       - checkout
-      - attach_workspace:
-          at: ~/constable
       - run:
           name: Install dependencies
           command: npm install
@@ -36,7 +34,7 @@ jobs:
 
 workflows:
   version: 2
-  main:
+  build-lint:
     jobs:
       - lint
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           at: ~/constable
       - run:
           name: Install dependencies
-          command: npm run install
+          command: npm install
       - run:
           name: Linting
           command: npm run lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,10 @@ jobs:
       - attach_workspace:
           at: ~/constable
       - run:
+        name: Linting
+        command: |
+          npm run lint
+      - run:
           name: Authenticate with registry
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/constable/.npmrc
       - run:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silvercar/js-constable",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Silvercar's JavaScript/TypeScript ESLint Config",
   "main": "index.js",
   "scripts": {
@@ -19,16 +19,17 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.7.0",
     "@typescript-eslint/parser": "^2.7.0",
+    "typescript": "^3.7.2"
+  },
+  "dependencies": {
+    "eslint-import-resolver-typescript": "^2.0.0",
+    "lodash.merge": "^4.6.2",
     "eslint": "^6.6.0",
     "eslint-config-airbnb-typescript": "^6.1.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-markdown": "^1.0.1",
     "eslint-plugin-react": "^7.16.0",
-    "eslint-plugin-react-hooks": "^1.7.0",
-    "typescript": "^3.7.2"
-  },
-  "dependencies": {
-    "lodash.merge": "^4.6.2"
+    "eslint-plugin-react-hooks": "^1.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "homepage": "https://github.com/silvercar/js-constable#readme",
   "devDependencies": {
-    "typescript": "^3.7.2"
   },
   "dependencies": {
     "eslint-import-resolver-typescript": "^2.0.0",
@@ -30,6 +29,7 @@
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-react-hooks": "^1.7.0",
     "@typescript-eslint/eslint-plugin": "^2.7.0",
-    "@typescript-eslint/parser": "^2.7.0"
+    "@typescript-eslint/parser": "^2.7.0",
+    "typescript": "^3.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,19 +17,19 @@
   },
   "homepage": "https://github.com/silvercar/js-constable#readme",
   "devDependencies": {
-  },
-  "dependencies": {
-    "eslint-import-resolver-typescript": "^2.0.0",
-    "lodash.merge": "^4.6.2",
+    "@typescript-eslint/eslint-plugin": "^2.7.0",
+    "@typescript-eslint/parser": "^2.7.0",
+    "typescript": "^3.7.2",
     "eslint": "^6.6.0",
     "eslint-config-airbnb-typescript": "^6.1.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-markdown": "^1.0.1",
     "eslint-plugin-react": "^7.16.0",
-    "eslint-plugin-react-hooks": "^1.7.0",
-    "@typescript-eslint/eslint-plugin": "^2.7.0",
-    "@typescript-eslint/parser": "^2.7.0",
-    "typescript": "^3.7.2"
+    "eslint-plugin-react-hooks": "^1.7.0"
+  },
+  "dependencies": {
+    "eslint-import-resolver-typescript": "^2.0.0",
+    "lodash.merge": "^4.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Silvercar's JavaScript/TypeScript ESLint Config",
   "main": "index.js",
   "scripts": {
+    "lint": "eslint ./ --ext .tsx,.ts,.js,.jsx",
     "test": "node_modules/.bin/eslint ."
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
   },
   "homepage": "https://github.com/silvercar/js-constable#readme",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.7.0",
-    "@typescript-eslint/parser": "^2.7.0",
     "typescript": "^3.7.2"
   },
   "dependencies": {
@@ -30,6 +28,8 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-markdown": "^1.0.1",
     "eslint-plugin-react": "^7.16.0",
-    "eslint-plugin-react-hooks": "^1.7.0"
+    "eslint-plugin-react-hooks": "^1.7.0",
+    "@typescript-eslint/eslint-plugin": "^2.7.0",
+    "@typescript-eslint/parser": "^2.7.0"
   }
 }

--- a/rules/common.js
+++ b/rules/common.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   rules: {
     // -- Error
-    quotes: ['error', 'single', { allowTemplateLiterals: true }]
+    quotes: ['error', 'single', { allowTemplateLiterals: true }],
     'no-shadow': 2,
     'default-case': 2,
     'max-params': ['error', 4],

--- a/rules/react.js
+++ b/rules/react.js
@@ -45,4 +45,9 @@ module.exports = {
     'react/no-array-index-key': 0,
     'react/prefer-stateless-function': 0,
   },
+  settings: {
+    'import/resolver': {
+      typescript: {},
+    },
+  },
 };

--- a/rules/react.js
+++ b/rules/react.js
@@ -40,7 +40,7 @@ module.exports = {
     'react/no-multi-comp': [1, { ignoreStateless: true }],
     'react-hooks/exhaustive-deps': 'warn',
     'react/destructuring-assignment': 1,
-
+    'no-shadow': 1,
     // -- Off
     'react/no-array-index-key': 0,
     'react/prefer-stateless-function': 0,

--- a/rules/react.js
+++ b/rules/react.js
@@ -41,6 +41,7 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'warn',
     'react/destructuring-assignment': 1,
     'no-shadow': 1,
+    'import/no-cycle': 1,
     // -- Off
     'react/no-array-index-key': 0,
     'react/prefer-stateless-function': 0,

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -17,5 +17,6 @@ module.exports = {
     // Off
     '@typescript-eslint/explicit-function-return-type': 0,
     '@typescript-eslint/explicit-member-accessibility': 0,
+    'react/prop-types': 0,
   },
 };


### PR DESCRIPTION
* Allow for absolute imports in linting without errors or warnings
  * `import { Something } from 'src/constants/specials';` instead of only allowing `import { Something } from '../../src/constants/specials';`
* Update `package.json` to require end-user to install required linting dependencies such as `eslint`, `eslint-import-resolver-typescript`, which will be more important in newer repos like `rac-web-silverware`